### PR TITLE
Add listener IDs to all listeners

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
   # where can i deploy <app>
   #
   # Displays the available environments for an application
-  robot.respond ///where\s+can\s+i\s+#{DeployPrefix}\s+([-_\.0-9a-z]+)///i, (msg) ->
+  robot.respond ///where\s+can\s+i\s+#{DeployPrefix}\s+([-_\.0-9a-z]+)///i, id:'deploy.list-targets', (msg) ->
     name = msg.match[1]
 
     try
@@ -40,7 +40,7 @@ module.exports = (robot) ->
   # deploys <app> in <env>
   #
   # Displays the available environments for an application
-  robot.respond DeploysPattern, (msg) ->
+  robot.respond DeploysPattern, id:'deploy.list', (msg) ->
     name        = msg.match[2]
     environment = msg.match[4] || 'production'
 
@@ -57,7 +57,7 @@ module.exports = (robot) ->
   # deploy hubot/topic-branch to staging
   #
   # Actually dispatch deployment requests to GitHub
-  robot.respond DeployPattern, (msg) ->
+  robot.respond DeployPattern, id:'deploy.deploy', (msg) ->
     task  = msg.match[1].replace(DeployPrefix, "deploy")
     force = msg.match[2] == '!'
     name  = msg.match[3]
@@ -107,5 +107,5 @@ module.exports = (robot) ->
   # deploy:version
   #
   # Useful for debugging
-  robot.respond ///#{DeployPrefix}\:version$///i, (msg) ->
+  robot.respond ///#{DeployPrefix}\:version$///i, id:'deploy.version', (msg) ->
     msg.send "hubot-deploy v#{Version}/hubot v#{robot.version}/node #{process.version}"

--- a/src/scripts/token.coffee
+++ b/src/scripts/token.coffee
@@ -20,13 +20,13 @@ DeploysPattern = Patterns.DeploysPattern
 TokenVerifier  = require(Path.join(__dirname, "..", "token_verifier")).TokenVerifier
 ###########################################################################
 module.exports = (robot) ->
-  robot.respond ///#{DeployPrefix}-token:set///i, (msg) ->
+  robot.respond ///#{DeployPrefix}-token:set///i, id:'deploy.token-set', (msg) ->
     user = robot.brain.userForId msg.envelope.user.id
     user.verifyToken = uuid.v4()
     robot.logger.info "user: #{user}\nid: #{user.id}\nroom: #{msg.envelope.user.id}"
     robot.send {room: msg.envelope.user.name}, "Enter your token here: " + HerokuUrl + "/hubot-deploy/token?verify_token=" + user.verifyToken + "&user_id=" + msg.envelope.user.id
 
-  robot.respond ///#{DeployPrefix}-token:reset///i, (msg) ->
+  robot.respond ///#{DeployPrefix}-token:reset///i, id:'deploy.token-reset', (msg) ->
     user = robot.brain.userForId msg.envelope.user.id
     delete(user.githubDeployToken)
     msg.reply "I nuked your deployment token. I'll use my default token until you configure another."


### PR DESCRIPTION
This allows one to add auth to these commands. Since the commands are
backed by GitHub tokens anyways, this isn't strictly necessary unless
you want to limit permissions more than in GitHub, but it does provide
an extra layer of protection should there be a bug.
